### PR TITLE
tddspry runner does not respect `--noinput` option

### DIFF
--- a/tddspry/django/runner.py
+++ b/tddspry/django/runner.py
@@ -18,7 +18,7 @@ class TestSuiteRunner(NoseTestSuiteRunner):
     """
     def run_suite(self, nose_argv):
         # Install necessary plugins
-        django_plugin = DjangoPlugin()
+        django_plugin = DjangoPlugin(self)
         result_plugin = ResultPlugin()
 
         plugins_to_add = [django_plugin, result_plugin]

--- a/tddspry/noseplugins/djangoplugin.py
+++ b/tddspry/noseplugins/djangoplugin.py
@@ -30,6 +30,11 @@ class DjangoPlugin(Plugin):
     settings = None
     verbosity = 1
 
+    def __init__(self, runner=None):
+        super(DjangoPlugin, self).__init__()
+        if runner:
+            self.interactive = runner.interactive
+
     def begin(self):
         from django.conf import settings
         from django.core.handlers.wsgi import WSGIHandler
@@ -217,7 +222,7 @@ class DjangoPlugin(Plugin):
             from django.test.simple import DjangoTestSuiteRunner
 
             # Initialize Django tests runner
-            runner = DjangoTestSuiteRunner(verbosity=self.verbosity)
+            runner = DjangoTestSuiteRunner(verbosity=self.verbosity, interactive=self.interactive)
 
             # New Django tests runner set ``DEBUG`` to False on setup test
             # environment, so we need to store real ``DEBUG`` value


### PR DESCRIPTION
This doesn't work:
    ./manage.py test --noinput

I suggest this hackish fix.
